### PR TITLE
Adds the method has_many to the entity.rb

### DIFF
--- a/lib/autotask_api/entity.rb
+++ b/lib/autotask_api/entity.rb
@@ -30,7 +30,7 @@ module AutotaskAPI
         query.field = field
         query.expression = id
       end
-      find_cache[id] ||= client.entities_for(query).first
+      find_cache[id] ||= client.entities_for(query)
     end
 
     def self.belongs_to(name, options = {})
@@ -38,11 +38,20 @@ module AutotaskAPI
       klass = "AutotaskAPI::#{(options[:class_name] || name).to_s.classify}"
       foreign_key = name.foreign_key
       define_method name do
-        klass.constantize.find send(foreign_key)
+        klass.constantize.find( send(foreign_key) ).first
       end
     end
 
     def self.has_one(name, options = {})
+      name = name.to_s
+      options.reverse_merge! foreign_key: self.to_s.foreign_key.camelize
+      klass = "AutotaskAPI::#{(options[:class_name] || name).to_s.classify}"
+      define_method name do
+        klass.constantize.find(id, options[:foreign_key]).first
+      end
+    end
+
+    def self.has_many(name, options = {})
       name = name.to_s
       options.reverse_merge! foreign_key: self.to_s.foreign_key.camelize
       klass = "AutotaskAPI::#{(options[:class_name] || name).to_s.classify}"

--- a/lib/autotask_api/service_call_ticket.rb
+++ b/lib/autotask_api/service_call_ticket.rb
@@ -2,6 +2,7 @@ module AutotaskAPI
   class ServiceCallTicket < Entity
     self.fields = [ :id, :service_call_id, :ticket_id ]
     belongs_to :service_call
-    has_one :service_call_ticket_resource
+    belongs_to :ticket
+    has_many :service_call_ticket_resources
   end
 end


### PR DESCRIPTION
The relationship between ServiceCallTicket and resource is many.
Many resources can be assigned to the same ServiceCall/Ticket.

This addresses issue #19 